### PR TITLE
fix: proper deletion even if missing alias

### DIFF
--- a/lib/indices.js
+++ b/lib/indices.js
@@ -130,25 +130,23 @@ exports.update = async (name, { body } = { body: {} }) => {
 
 exports.delete = async (name) => {
   const ops = {}
-  const {sourceIndex: index} = await findAliasIndex(name, ops)
   try {
+    const {sourceIndex: index} = await findAliasIndex(name, ops)
     ops.preChecks = await Promise.all([
       getOps((ops) => checkAliasAlreadyExists(name, ops)),
       getOps((ops) => checkIndexAlreadyExists(index, ops))
     ])
+    const cantRollbackAlias = (name, index, e, origin) => { throw e }
+    const cantRollbackIndex = (index, e, origin) => { throw e }
+    ops.deletions = await Promise.all([
+      getOps((ops) => deleteAlias(name, index, cantRollbackAlias, ops)),
+      getOps((ops) => deleteIndex(index, cantRollbackIndex, ops))
+    ])
+
+    return {name, index, ops}
   } catch (error) {
-    error.message = `The index (${index}) or alias (${name}) were missing: ` + error.message
+    error.message = `The alias (${name}) or the index it is pointing to, was missing: ` + error.message
     error.ops = ops
     throw Boom.boomify(error, {statusCode: 404})
   }
-
-  const cantRollback = (e) => {
-    throw e
-  }
-  ops.deletions = await Promise.all([
-    getOps((ops) => deleteAlias(name, index, cantRollback, ops)),
-    getOps((ops) => deleteIndex(index, cantRollback, ops))
-  ])
-
-  return {name, index, ops}
 }


### PR DESCRIPTION
In some cases, the deletion would not work as expectedto give a good feedback to the user (an http 404)
- if the `findAlias` would not return anything
- if the deletions would not work, the rollback `cantRollback`  would run, and throw the first argument, which was not the error ( index, for index deletion, alias for alias deletion )