### PR TITLE
fix: long stack traces should be active in dev

### DIFF
--- a/lib/es.js
+++ b/lib/es.js
@@ -1,4 +1,4 @@
-if (process.env.NODE_ENV !== 'production' || process.env.LEAISTIC_FORCE_LONG_STACK_TRACE) {
+if (process.env.LEAISTIC_FORCE_LONG_STACK_TRACE || process.env.NODE_ENV !== 'production') {
   // long stack traces could be harmful in production ( more memory, slower, etc. )
   require('trace')
 }


### PR DESCRIPTION
By default, without having to force them