### PR TITLE
fix: run post-reindex checks in parallel

### DIFF
--- a/lib/indices.js
+++ b/lib/indices.js
@@ -125,9 +125,9 @@ exports.update = async (name, { body } = { body: {} }) => {
     await reindex(name, sourceIndex, index, rollbackFromReindex, ops)
     try {
       ops.postReindex = await Promise.all([
-        await getOps((ops) => checkIndexAlreadyExists(sourceIndex, ops)),
-        await getOps((ops) => checkIndexAlreadyExists(index, ops)),
-        await getOps((ops) => checkAliasAlreadyExists(name, ops))
+        getOps((ops) => checkIndexAlreadyExists(sourceIndex, ops)),
+        getOps((ops) => checkIndexAlreadyExists(index, ops)),
+        getOps((ops) => checkAliasAlreadyExists(name, ops))
       ])
     } catch (error) {
       const origin = `the checks after ${sourceIndex} reindexation to ${index}, and before the switch of ${name} alias`


### PR DESCRIPTION
Fixes #29 `4.`