### PR TITLE
test: remove useless post-deletion index refresh

### DIFF
--- a/lib/hlrollbacks.test.js
+++ b/lib/hlrollbacks.test.js
@@ -17,7 +17,6 @@ describe('rollbackFromIndexCreation', () => {
   const ensureIndexIsDeleted = async ({index}) => {
     try {
       await es().indices.delete({index})
-      await es().indices.refresh({index})
     } catch (e) {
       // ignore
       expect(e instanceof esError).toBeTruthy()
@@ -96,7 +95,6 @@ describe('rollbackFromAliasCreation', () => {
   const ensureIndexIsDeleted = async ({index}) => {
     try {
       await es().indices.delete({index})
-      await es().indices.refresh({index})
     } catch (e) {
       // ignore
       expect(e instanceof esError).toBeTruthy()
@@ -182,7 +180,6 @@ describe('rollbackFromReindex', () => {
   const ensureIndexIsDeleted = async ({index}) => {
     try {
       await es().indices.delete({index})
-      await es().indices.refresh({index})
     } catch (e) {
       // ignore
       expect(e instanceof esError).toBeTruthy()
@@ -261,7 +258,6 @@ describe('rollbackFromAliasSwitch', () => {
   const ensureIndexIsDeleted = async ({index}) => {
     try {
       await es().indices.delete({index})
-      await es().indices.refresh({index})
     } catch (e) {
       // ignore
       expect(e instanceof esError).toBeTruthy()

--- a/lib/rollbacks.test.js
+++ b/lib/rollbacks.test.js
@@ -202,7 +202,6 @@ describe('rollbackIndexCreation', () => {
   const ensureIndexIsDeleted = async ({index}) => {
     try {
       await es().indices.delete({index})
-      await es().indices.refresh({index})
     } catch (e) {
       // ignore
       expect(e instanceof esError).toBeTruthy()


### PR DESCRIPTION
not only it is useless, but it also throws a catched error each time.

Solves #40 