### PR TITLE
feat(lib): allow to provide your own reindexer when used as a lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ await create('an-index', indexTemplate)
 
 ### Update
 
+#### With automatic reindexation ( e.g. for index template change, if compatible )
+
 ```javascript
 const {update} = require('leaistic')
 
@@ -128,6 +130,46 @@ const indexTemplate = {
 // create an index, optionally with an indexTemplate that should match it:
 await update('an-index', indexTemplate)
 ```
+
+#### With manual reindexation ( e.g. for creating a whole new version of the data )
+
+```javascript
+const {update} = require('leaistic')
+
+const indexTemplate = {
+  index_patterns: ['myindex-*'],
+  settings: {
+    number_of_shards: 2
+  }
+}
+
+const data = [
+  { hello: 'world'},
+  { hello: 'foo'},
+  { hello: 'bar'},
+  { hello: 'baz'}
+]
+
+const reindexer = async (indexName, client) => client.bulk({
+    refresh: true,
+    body: data.reduce((acc, current) => {
+      return acc.concat([
+        {
+          index: {
+            _index: indexName,
+            _id: current.hello,
+          },
+        },
+        current
+      ])
+    }, [])
+  })
+}
+
+// create an index, optionally with an indexTemplate that should match it:
+await update('an-index', indexTemplate, reindexer)
+```
+
 
 ### Deletion
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ exports.start = start
 
 // use a high level library
 exports.create = (name, {indexTemplate} = {}) => lib.create(name, {body: indexTemplate})
-exports.update = (name, {indexTemplate} = {}) => lib.update(name, {body: indexTemplate})
+exports.update = (name, {indexTemplate} = {}, reindexer) => lib.update(name, {body: indexTemplate}, reindexer)
 exports.delete = name => lib.delete(name)
 
 exports.newIndexName = (aliasName) => lib.suffix(aliasName)

--- a/lib/indices.js
+++ b/lib/indices.js
@@ -12,8 +12,11 @@ const {
   findAliasIndex,
   createAlias,
   switchAlias,
-  reindex
+  reindex,
+  client
 } = require('./ops')
+
+const {log} = require('./logger')
 
 const {
   rollbackFromAliasCreation,
@@ -73,8 +76,9 @@ exports.create = async (name, { body } = { body: {} }) => {
   })
 }
 
-exports.update = async (name, { body } = { body: {} }) => {
-  const ops = {}
+exports.update = async (name, { body } = { body: {} }, reindexer) => {
+  let ops = {}
+
   return indexUpdate(name, async () => {
     await checkAliasAlreadyExists(name, ops)
     const {sourceIndex} = await findAliasIndex(name, ops)
@@ -85,7 +89,23 @@ exports.update = async (name, { body } = { body: {} }) => {
     const index = suffix(name)
 
     await createIndex(index, rollbackFromIndexCreation(ops), ops)
-    await reindex(name, sourceIndex, index, rollbackFromReindex(ops), ops)
+
+    // custom reindexer should take care of the refresh
+    reindexer = reindexer || (name => reindex(name, sourceIndex, index, rollbackFromReindex(ops), ops))
+
+    try {
+      const reindexResult = await reindexer(name, client())
+      log().info(reindexResult, `✅"${index}" reindexation done`)
+      if (reindexResult.ops) {
+        ops = { ...ops, ...reindexResult.ops }
+      } else {
+        ops.reindex = reindexResult || { failures: [] }
+      }
+    } catch (err) {
+      log().error({ err }, `🚨"${index}" reindexation failed`)
+      rollbackFromReindex(ops)
+    }
+
     await manageErrors(async () => {
       ops.postReindex = await Promise.all([
         getOps((ops) => checkIndexAlreadyExists(sourceIndex, ops)),

--- a/lib/indices.test.js
+++ b/lib/indices.test.js
@@ -172,6 +172,105 @@ describe('update', () => {
     expect(res.ops.template).toHaveProperty('acknowledged', true)
   })
 
+  it(`should allow updating an index with a template and a custom reindexer`, async () => {
+    // use a new name to avoid concurrent conflict with previous test
+    const name = uuid()
+    const index = suffix(name)
+
+    await es().indices.create({index})
+    await es().indices.refresh({index})
+    await es().indices.putAlias({name, index})
+
+    const body = {
+      'index_patterns': [`${name}-*`],
+      'mappings': {
+        '_doc': {
+          '_source': {
+            'enabled': false
+          },
+          'properties': {
+            'hello': { type: 'keyword' }
+          }
+        }
+      }
+    }
+
+    const data = [
+      { hello: 'world' },
+      { hello: 'foo' },
+      { hello: 'bar' },
+      { hello: 'baz' }
+    ]
+
+    const reindexer = async (indexName, client) => client.bulk({
+      refresh: true,
+      body: data.reduce((acc, current) => {
+        return acc.concat([
+          {
+            index: {
+              _index: indexName,
+              _type: '_doc'
+            }
+          },
+          current
+        ])
+      }, [])
+    })
+
+    const res = await update(name, {body}, reindexer)
+
+    // cleanup
+    try {
+      await es().indices.delete({index})
+    } catch (e) {}
+    try {
+      await es().indices.deleteAlias({name, index})
+    } catch (e) {}
+
+    const indexShouldMatch = new RegExp(`^${name}-\\d+-\\d+-\\d+t\\d+:\\d+:\\d+.\\d+z`)
+    expect(res.name).toBe(name)
+    expect(res.index).toMatch(indexShouldMatch)
+    expect(res.sourceIndex).toMatch(indexShouldMatch)
+    expect(res.ops).toHaveProperty('aliasExists', true)
+
+    expect(res.ops).toHaveProperty('findAlias')
+    expect(res.ops.findAlias[index]).toBeDefined()
+    expect(res.ops.findAlias[index]).toHaveProperty('aliases')
+    expect(res.ops.findAlias[index].aliases).toHaveProperty(name, {})
+
+    expect(res.ops).toHaveProperty('index')
+    expect(res.ops.index).toHaveProperty('acknowledged', true)
+    expect(res.ops.index).toHaveProperty('shards_acknowledged', true)
+    expect(res.ops.index).toHaveProperty('index')
+    expect(res.ops.index.index).toMatch(indexShouldMatch)
+
+    expect(res.ops).toHaveProperty('postReindex')
+    expect(res.ops.postReindex).toEqual(expect.any(Array))
+    expect(res.ops.postReindex.length).toBe(3)
+    expect(res.ops.postReindex[0]).toHaveProperty('indexExists', true)
+    expect(res.ops.postReindex[1]).toHaveProperty('indexExists', true)
+    expect(res.ops.postReindex[2]).toHaveProperty('aliasExists', true)
+
+    expect(res.ops).toHaveProperty('postAliasSwitch')
+    expect(res.ops.postAliasSwitch).toEqual(expect.any(Array))
+    expect(res.ops.postAliasSwitch.length).toBe(2)
+
+    expect(res.ops.postAliasSwitch[0]).toHaveProperty('indexDeletion', {acknowledged: true})
+    expect(res.ops.postAliasSwitch[1]).toHaveProperty('aliasExists', true)
+
+    expect(res.ops).toHaveProperty('reindex')
+
+    expect(res.ops).toHaveProperty('switchAlias')
+    expect(res.ops.switchAlias).toHaveProperty('acknowledged', true)
+
+    expect(res.ops.index.acknowledged).toBe(true)
+    expect(res.ops.index.shards_acknowledged).toBe(true)
+    expect(res.ops.index.index).toEqual(res.index)
+
+    expect(res.ops).toHaveProperty('template')
+    expect(res.ops.template).toHaveProperty('acknowledged', true)
+  })
+
   // nominal - can be useful for migrating the index version after an ES update
   it(`should allow updating an index with no template`, async () => {
     const res = await update(name)

--- a/lib/ops.js
+++ b/lib/ops.js
@@ -5,6 +5,8 @@ const {manageErrors} = require('./errors')
 const {indexName, indexTemplate, validate} = require('./validation')
 const {log} = require('./logger')
 
+exports.client = es
+
 exports.shouldUpdateTemplate = (template) => template ? (!!Object.keys(template).length) : false
 
 exports.checkAliasAlreadyExists = async (_name, ops = {}) => {

--- a/lib/ops.test.js
+++ b/lib/ops.test.js
@@ -139,7 +139,7 @@ describe('updateTemplate', () => {
   })
 })
 
-describe('createIndex', async () => {
+describe('createIndex', () => {
   const name = uuid()
   const index = suffix(name)
 
@@ -186,7 +186,7 @@ describe('createIndex', async () => {
   })
 })
 
-describe('deleteIndex', async () => {
+describe('deleteIndex', () => {
   const name = uuid()
   const index = suffix(name)
 
@@ -312,7 +312,7 @@ describe('checkIndexDoesNotExist', () => {
   })
 })
 
-describe('reindex', async () => {
+describe('reindex', () => {
   const name = uuid()
   const sourceIndex = suffix(name)
   const index = `${name}-2`
@@ -379,7 +379,7 @@ describe('reindex', async () => {
   })
 })
 
-describe('createAlias', async () => {
+describe('createAlias', () => {
   const name = uuid()
   const index = suffix(name)
 
@@ -459,7 +459,7 @@ describe('createAlias', async () => {
   })
 })
 
-describe('deleteAlias', async () => {
+describe('deleteAlias', () => {
   const name = uuid()
   const index = suffix(name)
   const otherIndex = suffix(name, new Date(Math.random() * 1e14))
@@ -660,7 +660,7 @@ describe('findAliasIndex', () => {
   })
 })
 
-describe('switchAlias', async () => {
+describe('switchAlias', () => {
   const name = uuid()
   const index = suffix(name)
   const destinationIndex = suffix(name)

--- a/lib/rollbacks.test.js
+++ b/lib/rollbacks.test.js
@@ -7,7 +7,7 @@ const {
   rollbackIndexCreation,
   rollbackAliasSwitch
 } = require('./rollbacks')
-const {es, esError} = require('./es')
+const {es, esError, awaitRefresh} = require('./es')
 
 jest.setTimeout(60000)
 
@@ -99,6 +99,7 @@ describe('rollbackAliasSwitch', () => {
       ensureIndexIsDeleted({index}),
       ensureIndexIsDeleted({index: sourceIndex})
     ])
+    await awaitRefresh()
   })
 
   it(`should revert an existing alias`, async () => {


### PR DESCRIPTION
see #10 . Does only solve the `lib` usage, micro-service one will need more work